### PR TITLE
Wait for connection check result before determining warnings

### DIFF
--- a/src/composables/useWarnings/useWarnings.ts
+++ b/src/composables/useWarnings/useWarnings.ts
@@ -10,7 +10,7 @@ const { connection } = useConnection();
 const { webRTCLeaking } = useWebRtc();
 
 const dohDisable = computed(() => connection.value.isMullvad && isMullvadDoh.value);
-const dohEnable = computed(() => !connection.value.isMullvad && !isMullvadDoh.value);
+const dohEnable = computed(() => connection.value.isMullvad === false && !isMullvadDoh.value);
 const dohLeak = computed(() => isMullvadDoh.value && isthirdPartyDns.value);
 const dnsLeak = computed(() => connection.value.isMullvad && isthirdPartyDns.value);
 

--- a/src/helpers/connCheck.ts
+++ b/src/helpers/connCheck.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
-import type { AmIMullvadServerResponse, Connection, Ipv4ServerResponse } from '@/helpers/connCheck.types';
+import type {
+  AmIMullvadServerResponse,
+  Connection,
+  Ipv4ServerResponse,
+} from '@/helpers/connCheck.types';
 
 /*
 n is an optional parameter to retry the connCheck any number of time.
@@ -17,7 +21,9 @@ export const connCheck = async (n = 3): Promise<Connection> => {
 
     let ipv6;
     try {
-      const { data: ipv6Data} = await axios.get<AmIMullvadServerResponse>('https://ipv6.am.i.mullvad.net/json');
+      const { data: ipv6Data } = await axios.get<AmIMullvadServerResponse>(
+        'https://ipv6.am.i.mullvad.net/json',
+      );
       ipv6 = ipv6Data.ip;
     } catch (e) {
       if (__DEV__) {
@@ -33,7 +39,7 @@ export const connCheck = async (n = 3): Promise<Connection> => {
       server: data.mullvad_exit_ip_hostname,
       protocol: data.mullvad_server_type,
       provider: data.organization,
-      isMullvad: data.mullvad_exit_ip ?? false,
+      isMullvad: data.mullvad_exit_ip ?? null,
     };
   } catch (error) {
     if (n === 1) throw new Error('Connection check failed.');

--- a/src/helpers/connCheck.types.ts
+++ b/src/helpers/connCheck.types.ts
@@ -28,8 +28,8 @@ export type Connection = {
   country?: string;
   ip?: string;
   ipv6?: string;
-  isMullvad: boolean;
+  isMullvad: boolean | null;
   protocol?: string;
   provider?: string;
   server?: string;
-}
+};


### PR DESCRIPTION
I noticed that the `dohEnable` warning was popping up every time that you expand the extension window. This is because the extension defaults `isMullvad` to `false`. If we default to a tertiary value, (i.e. `null`) then we can wait until the connection status is resolved as a boolean value.