### PR TITLE
Remove outdated conncheck retry workaround

### DIFF
--- a/src/helpers/connCheck.ts
+++ b/src/helpers/connCheck.ts
@@ -4,19 +4,11 @@ import type {
   Ipv4ServerResponse,
 } from '@/helpers/connCheck.types';
 
-/*
-By default, it will retry twice because after connecting/disconnecting to/from Mullvad server, the first request results in a NetworkError and the second is successful.
+export const connCheckIpv4 = async (): Promise<Connection> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 6000);
 
-It's a workaround for the following bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1706377
-Workaround can be removed when Mullvad Browser 14.0 is released (the bug is fixed!).
-*/
-const MAX_RETRIES = 3;
-
-export const connCheckIpv4 = async (retries = MAX_RETRIES): Promise<Connection> => {
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 6000);
-
     const response = await fetch('https://ipv4.am.i.mullvad.net/json', {
       method: 'GET',
       headers: {
@@ -37,12 +29,11 @@ export const connCheckIpv4 = async (retries = MAX_RETRIES): Promise<Connection> 
       isMullvad: data.mullvad_exit_ip ?? false,
     };
   } catch (error) {
-    if (retries === 1) throw new Error('IPv4 connection check failed.');
-    return connCheckIpv4(retries - 1);
+    throw new Error('IPv4 connection check failed.');
   }
 };
 
-export const connCheckIpv6 = async (retries = MAX_RETRIES): Promise<string | undefined> => {
+export const connCheckIpv6 = async (): Promise<string | undefined> => {
   try {
     const response = await fetch('https://ipv6.am.i.mullvad.net/json', {
       method: 'GET',
@@ -56,7 +47,6 @@ export const connCheckIpv6 = async (retries = MAX_RETRIES): Promise<string | und
     if (__DEV__) {
       console.log(`[conCheck IPv6]: Error trying to get ipv6 data: ${(e as Error).message}`);
     }
-    if (retries === 1) return undefined;
-    return connCheckIpv6(retries - 1);
+    return undefined;
   }
 };


### PR DESCRIPTION
Merging can happen once Mullvad Browser 14.0 is out.