### PR TITLE
Make background persistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mullvad-browser-extension",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mullvad-browser-extension",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "ipaddr.js": "^2.2.0",
         "naive-ui": "^2.40.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mullvad-browser-extension",
   "displayName": "Mullvad Browser Extension",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Improve your Mullvad VPN experience, in your browser.",
   "private": true,
   "engines": {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -24,7 +24,7 @@ export async function getManifest() {
     },
     background: {
       page: './dist/background/index.html',
-      persistent: false,
+      persistent: true,
     },
     icons: {
       '16': './assets/mullvad-logo.svg',

--- a/updates.json
+++ b/updates.json
@@ -52,8 +52,8 @@
           }
         },
         {
-          "version": "0.9.2",
-          "update_link": "https://cdn.mullvad.net/browser-extension/0.9.2/mullvad-browser-extension-0.9.2.xpi",
+          "version": "0.9.3",
+          "update_link": "https://cdn.mullvad.net/browser-extension/0.9.3/mullvad-browser-extension-0.9.3.xpi",
           "applications": {
             "gecko": { "strict_min_version": "91.1.0" }
           }


### PR DESCRIPTION
It seems with the latest update the background page doesn't persist on restart.

Since we're not planning yet to move to MV3 or support Android, it's fine to make it persistent.