### PR TITLE
Block speculative requests

### DIFF
--- a/src/helpers/socksProxy.ts
+++ b/src/helpers/socksProxy.ts
@@ -66,7 +66,11 @@ export const handleProxyRequest = async (details: browser.proxy._OnRequestDetail
     const proxiedHosts = Object.keys(hostProxiesParsed);
     const currentHost = getCurrentHost(details);
 
-    if (excludedHostsParsed.includes(currentHost) || isLocalOrReservedIP(currentHost)) {
+    // Since we can't identify speculative requests origin, we need to block them
+    // See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy
+    if (details.type === 'speculative') {
+      return { cancel: true };
+    } else if (excludedHostsParsed.includes(currentHost) || isLocalOrReservedIP(currentHost)) {
       return { type: 'direct' };
     } else if (
       proxiedHosts.includes(currentHost) &&


### PR DESCRIPTION
Since we can't identify speculative requests origin, we need to block them.

Reference: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy

Note: I was initially surprised this is not something we would have caught on earlier, and it seems this is because when I first implemented proxy support for that extension, there was no mention of speculative requests on MDN.
It would be good to think about how we avoid missing relevant changes in the future.