### PR TITLE
Reload on proxy change

### DIFF
--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -12,7 +12,7 @@ import { updateCurrentTabProxyBadge } from '@/helpers/proxyBadge';
 import useActiveTab from '@/composables/useActiveTab';
 import useConnection from '@/composables/useConnection';
 import useStore from '@/composables/useStore';
-import { reloadMatchingTabs } from '@/helpers/tabs';
+import { reloadGlobalProxiedTabs, reloadMatchingTabs } from '@/helpers/tabs';
 
 const baseConfig: Partial<ProxyInfo> = {
   port: 1080,
@@ -38,10 +38,16 @@ const currentHostProxyEnabled = computed(
 const globalProxyDNSEnabled = computed(() => globalProxy.value?.proxyDNS ?? false);
 const currentHostProxyDNSEnabled = computed(() => currentHostProxyDetails.value?.proxyDNS ?? false);
 
+const combinedHosts = computed(() => {
+  const allHosts = [...Object.keys(hostProxiesDetails.value), ...excludedHosts.value];
+  return [...new Set(allHosts)].sort((a, b) => a.localeCompare(b));
+});
+
 const toggleGlobalProxy = () => {
   globalProxyDetails.value.socksEnabled = !globalProxyDetails.value.socksEnabled;
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadGlobalProxiedTabs(combinedHosts.value);
 };
 const toggleCurrentHostProxy = () => {
   hostProxiesDetails.value[activeTabHost.value].socksEnabled = !currentHostProxyEnabled.value;
@@ -67,6 +73,7 @@ const toggleGlobalProxyDNS = () => {
   globalProxyDetails.value.proxyDNS = updatedGlobalProxyDNS;
   globalProxy.value.proxyDNS = updatedGlobalProxyDNS;
   updateCurrentTabProxyBadge();
+  reloadGlobalProxiedTabs(combinedHosts.value);
 };
 const toggleCurrentHostProxyDNS = () => {
   const updatedCurrentHostProxyDNS = !currentHostProxyDetails.value.proxyDNS;
@@ -105,6 +112,7 @@ const setGlobalProxy = ({
 
   updateConnection();
   reloadOptions();
+  reloadGlobalProxiedTabs(combinedHosts.value);
 };
 
 const setCurrentHostProxy = (
@@ -155,6 +163,7 @@ const removeGlobalProxy = () => {
   globalProxyDetails.value = {} as ProxyDetails;
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadGlobalProxiedTabs(combinedHosts.value);
 };
 
 const allowProxy = (host: string) => {

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -12,6 +12,7 @@ import { updateCurrentTabProxyBadge } from '@/helpers/proxyBadge';
 import useActiveTab from '@/composables/useActiveTab';
 import useConnection from '@/composables/useConnection';
 import useStore from '@/composables/useStore';
+import { reloadMatchingTabs } from '@/helpers/tabs';
 
 const baseConfig: Partial<ProxyInfo> = {
   port: 1080,
@@ -46,16 +47,19 @@ const toggleCurrentHostProxy = () => {
   hostProxiesDetails.value[activeTabHost.value].socksEnabled = !currentHostProxyEnabled.value;
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadMatchingTabs(activeTabHost.value);
 };
 
 const toggleCustomProxy = (host: string) => {
   hostProxiesDetails.value[host].socksEnabled = !hostProxiesDetails.value[host].socksEnabled;
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadMatchingTabs(host);
 };
 const toggleCustomProxyDNS = (host: string) => {
   hostProxiesDetails.value[host].proxyDNS = !hostProxiesDetails.value[host].proxyDNS;
   updateCurrentTabProxyBadge();
+  reloadMatchingTabs(host);
 };
 
 const toggleGlobalProxyDNS = () => {
@@ -69,6 +73,7 @@ const toggleCurrentHostProxyDNS = () => {
   hostProxiesDetails.value[activeTabHost.value].proxyDNS = updatedCurrentHostProxyDNS;
   hostProxies.value[activeTabHost.value].proxyDNS = updatedCurrentHostProxyDNS;
   updateCurrentTabProxyBadge();
+  reloadMatchingTabs(activeTabHost.value);
 };
 
 const setGlobalProxy = ({
@@ -133,6 +138,7 @@ const setCurrentHostProxy = (
   hostProxiesDetails.value = { ...hostProxiesDetails.value, [host]: newHostProxyDetails };
 
   reloadOptions();
+  reloadMatchingTabs(host);
 };
 
 const removeCustomProxy = (host: string) => {
@@ -141,6 +147,7 @@ const removeCustomProxy = (host: string) => {
   updateConnection();
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadMatchingTabs(host);
 };
 
 const removeGlobalProxy = () => {
@@ -154,12 +161,14 @@ const allowProxy = (host: string) => {
   excludedHosts.value = excludedHosts.value.filter((excluded) => excluded !== host);
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadMatchingTabs(host);
 };
 
 const neverProxyHost = (host: string) => {
   excludedHosts.value = [...excludedHosts.value, host];
   updateCurrentTabProxyBadge();
   reloadOptions();
+  reloadMatchingTabs(host);
 };
 
 const useSocksProxy = () => {

--- a/src/helpers/tabs.ts
+++ b/src/helpers/tabs.ts
@@ -8,3 +8,25 @@ export const reloadMatchingTabs = async (url: string) => {
     }
   });
 };
+
+export const reloadGlobalProxiedTabs = async (excludedURLs: string[]) => {
+  const tabs = await browser.tabs.query({ url: '*://*/*' });
+
+  const tabsToReload = tabs.filter((tab) => {
+    if (!tab.url) {
+      return false;
+    }
+    return !isExcludedURL(tab.url, excludedURLs);
+  });
+
+  tabsToReload.forEach((tab) => {
+    if (tab.id) {
+      browser.tabs.reload(tab.id);
+    }
+  });
+};
+
+const isExcludedURL = (url: string, excludedURLs: string[]): boolean => {
+  const { hostname } = new URL(url);
+  return excludedURLs.some((excludedUrl) => hostname === excludedUrl);
+};

--- a/src/helpers/tabs.ts
+++ b/src/helpers/tabs.ts
@@ -1,0 +1,10 @@
+export const reloadMatchingTabs = async (url: string) => {
+  const urlPattern = `*://*.${url}/*`;
+
+  const tabs = await browser.tabs.query({ url: urlPattern });
+  tabs.forEach((tab) => {
+    if (tab.id) {
+      browser.tabs.reload(tab.id);
+    }
+  });
+};


### PR DESCRIPTION
- When a custom proxy is set, any tab matching the website configure will now reload.
- When changing the proxy for all websites, all tabs should reload, except the excluded hosts and the websites with a specific proxy.