### PR TITLE
No nesting when only one city

### DIFF
--- a/src/components/Location.vue
+++ b/src/components/Location.vue
@@ -107,7 +107,7 @@ const selectLocation = (connection: HistoryEntry) => {
 
         <div v-if="cities?.length === 1">
           <n-space vertical class="ml-8">
-            <span class="city-name">{{ cities[0].city }}</span>
+            <span class="text-sm">{{ cities[0].city }}</span>
             <n-button
               v-for="proxy in cities[0].proxyList"
               :key="proxy.hostname"
@@ -172,9 +172,5 @@ const selectLocation = (connection: HistoryEntry) => {
 <style scoped>
 p {
   color: var(--light-grey);
-}
-
-.city-name {
-  font-size: 14px;
 }
 </style>


### PR DESCRIPTION
Fixes #292

Idea and original code by @Sannym 

When there's only one city, show the city name and the relays without having to click to expand
<img width="394" height="496" alt="image" src="https://github.com/user-attachments/assets/f86d2dfb-d14e-4371-9300-ec42415e0fea" />
