### PR TITLE
Fixed subdomains not inheriting proxies

### DIFF
--- a/src/components/Proxy/PopupProxyPanel.vue
+++ b/src/components/Proxy/PopupProxyPanel.vue
@@ -20,15 +20,16 @@ const showDetailsAllWebsites = ref(false);
 const showDetailsCurrentTab = ref(false);
 const showDetailsRandom = ref(false);
 
-const { activeTabDomain, isAboutPage, isExtensionPage } = useActiveTab();
+const { isAboutPage, isExtensionPage } = useActiveTab();
 const { proxySelect } = useLocations();
 const { isGranted, requestPermissions } = useProxyPermissions();
 const { toggleRandomProxyMode, randomProxyMode } = useRandomProxy();
 const {
   allowProxy,
+  currentHostProxyDetails,
   currentHostProxyEnabled,
-  hostProxiesDetails,
-  excludedHosts,
+  currentHostExcluded,
+  currentEffectiveProxyDomain,
   globalProxyEnabled,
   globalProxyDetails,
   neverProxyHost,
@@ -43,16 +44,12 @@ import useStore from '@/composables/useStore';
 const { flatProxiesList } = useStore();
 const { getSocksProxies } = useSocksProxies();
 
-const currentTabExcluded = computed(() => excludedHosts.value.includes(activeTabDomain.value));
-
-const currentTabProxyDetails = computed(() => {
-  return hostProxiesDetails.value[activeTabDomain.value] || null;
-});
-
 const isCurrentTabProxyOverriden = computed(() => randomProxyMode.value);
 
 const isAllWebsitesProxyOverriden = computed(() =>
-  !randomProxyMode.value && !currentHostProxyEnabled.value ? false : true,
+  !randomProxyMode.value && !currentHostProxyEnabled.value && !currentHostExcluded.value
+    ? false
+    : true,
 );
 
 watch(isGranted, (newValue) => {
@@ -74,16 +71,18 @@ watch(isGranted, (newValue) => {
         @click="showDetailsCurrentTab = !showDetailsCurrentTab"
       >
         <div class="flex">
-          <TitleCategory :level="3" title="Current tab" />
-          <InUseTag v-if="!isCurrentTabProxyOverriden && currentHostProxyEnabled" />
+          <TitleCategory :level="3" title="Current domain" />
+          <InUseTag
+            v-if="!isCurrentTabProxyOverriden && (currentHostProxyEnabled || currentHostExcluded)"
+          />
         </div>
 
         <div class="flex flex-row items-center">
           <n-switch
-            v-if="currentTabProxyDetails"
+            v-if="currentHostProxyDetails && !currentHostExcluded"
             :value="currentHostProxyEnabled"
             :disabled="isCurrentTabProxyOverriden"
-            @update-value="toggleDomainProxy(activeTabDomain)"
+            @update-value="toggleDomainProxy(currentEffectiveProxyDomain)"
             @click.stop
             class="mr-2"
           />
@@ -96,54 +95,54 @@ watch(isGranted, (newValue) => {
       </div>
 
       <n-collapse-transition :show="showDetailsCurrentTab" class="mt-2">
-        <div class="flex items-center mb-2">
+        <div v-if="!currentHostExcluded" class="flex items-center mb-2">
           <n-icon size="20" class="mr-3">
             <FeInfo />
           </n-icon>
           <p>
-            Proxy configured for <strong>{{ activeTabDomain }}</strong
+            Proxy configured for <strong>{{ currentEffectiveProxyDomain }}</strong
             >.
           </p>
         </div>
 
-        <div v-if="currentTabExcluded" class="mb-3">
-          <p class="mb-4">{{ activeTabDomain }} is set to never be proxied.</p>
-          <Button size="small" @click="allowProxy(activeTabDomain)"
-            >Allow proxy for {{ activeTabDomain }}</Button
+        <div v-if="currentHostExcluded" class="mb-3">
+          <p class="mb-4">{{ currentEffectiveProxyDomain }} is set to never be proxied.</p>
+          <Button size="small" @click="allowProxy(currentEffectiveProxyDomain)"
+            >Allow proxy for {{ currentEffectiveProxyDomain }}</Button
           >
         </div>
-        <div v-if="!currentTabExcluded">
-          <div v-if="currentTabProxyDetails" class="flex justify-between">
+        <div v-if="!currentHostExcluded">
+          <div v-if="currentHostProxyDetails" class="flex justify-between">
             <div class="mb-2">
               <h4 class="font-semibold">
-                {{ currentTabProxyDetails.city }}, {{ currentTabProxyDetails.country }}
+                {{ currentHostProxyDetails.city }}, {{ currentHostProxyDetails.country }}
               </h4>
               <div class="flex">
                 <h4 class="font-semibold">Server</h4>
-                <div class="ml-2">{{ currentTabProxyDetails.server }}</div>
+                <div class="ml-2">{{ currentHostProxyDetails.server }}</div>
               </div>
             </div>
           </div>
 
           <div class="flex justify-between">
-            <Button size="small" @click="proxySelect(activeTabDomain)">
-              {{ currentTabProxyDetails ? 'Change location' : 'Select location' }}
+            <Button size="small" @click="proxySelect(currentEffectiveProxyDomain)">
+              {{ currentHostProxyDetails ? 'Change location' : 'Select location' }}
             </Button>
             <SplitButton
-              v-if="currentTabProxyDetails"
+              v-if="currentHostProxyDetails"
               size="small"
               main-color="error"
               sub-color="white"
               main-text="Reset"
               sub-text="Never proxy"
-              @main-click="removeCustomProxy(activeTabDomain)"
-              @sub-click="neverProxyHost(activeTabDomain)"
+              @main-click="removeCustomProxy(currentEffectiveProxyDomain)"
+              @sub-click="neverProxyHost(currentEffectiveProxyDomain)"
             />
             <Button
               v-else
               size="small"
               class="flex items-center justify-center"
-              @click="neverProxyHost(activeTabDomain)"
+              @click="neverProxyHost(currentEffectiveProxyDomain)"
             >
               Never proxy
             </Button>

--- a/src/components/Proxy/PopupProxyPanel.vue
+++ b/src/components/Proxy/PopupProxyPanel.vue
@@ -17,7 +17,7 @@ import useRandomProxy from '@/composables/useRandomProxy';
 import useSocksProxy from '@/composables/useSocksProxy';
 
 const showDetailsAllWebsites = ref(false);
-const showDetailsCurrentTab = ref(false);
+const showDetailsCurrentDomain = ref(false);
 const showDetailsRandom = ref(false);
 
 const { isAboutPage, isExtensionPage } = useActiveTab();
@@ -44,7 +44,7 @@ import useStore from '@/composables/useStore';
 const { flatProxiesList } = useStore();
 const { getSocksProxies } = useSocksProxies();
 
-const isCurrentTabProxyOverriden = computed(() => randomProxyMode.value);
+const isCurrentDomainProxyOverriden = computed(() => randomProxyMode.value);
 
 const isAllWebsitesProxyOverriden = computed(() =>
   !randomProxyMode.value && !currentHostProxyEnabled.value && !currentHostExcluded.value
@@ -68,12 +68,14 @@ watch(isGranted, (newValue) => {
     <div v-if="!isAboutPage && !isExtensionPage" class="border-[#354f6b] border-b-1 mb-3 pb-3">
       <div
         class="flex justify-between cursor-pointer"
-        @click="showDetailsCurrentTab = !showDetailsCurrentTab"
+        @click="showDetailsCurrentDomain = !showDetailsCurrentDomain"
       >
         <div class="flex">
           <TitleCategory :level="3" title="Current domain" />
           <InUseTag
-            v-if="!isCurrentTabProxyOverriden && (currentHostProxyEnabled || currentHostExcluded)"
+            v-if="
+              !isCurrentDomainProxyOverriden && (currentHostProxyEnabled || currentHostExcluded)
+            "
           />
         </div>
 
@@ -81,20 +83,20 @@ watch(isGranted, (newValue) => {
           <n-switch
             v-if="currentHostProxyDetails && !currentHostExcluded"
             :value="currentHostProxyEnabled"
-            :disabled="isCurrentTabProxyOverriden"
+            :disabled="isCurrentDomainProxyOverriden"
             @update-value="toggleDomainProxy(currentEffectiveProxyDomain)"
             @click.stop
             class="mr-2"
           />
 
           <n-icon size="20" class="cursor-pointer">
-            <FeChevronUp v-if="showDetailsCurrentTab" />
+            <FeChevronUp v-if="showDetailsCurrentDomain" />
             <FeChevronDown v-else />
           </n-icon>
         </div>
       </div>
 
-      <n-collapse-transition :show="showDetailsCurrentTab" class="mt-2">
+      <n-collapse-transition :show="showDetailsCurrentDomain" class="mt-2">
         <div v-if="!currentHostExcluded" class="flex items-center mb-2">
           <n-icon size="20" class="mr-3">
             <FeInfo />

--- a/src/composables/useActiveTab.ts
+++ b/src/composables/useActiveTab.ts
@@ -1,6 +1,5 @@
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import { getActiveTabDetails } from '@/helpers/tabs';
-import { checkDomain } from '@/helpers/domain';
 
 const activeTabHost = ref('');
 const isAboutPage = ref(false);
@@ -17,15 +16,10 @@ const getActiveTab = async () => {
   isAboutPage.value = isAboutPageValue;
   isExtensionPage.value = isExtensionPageValue; // TODO is this value used anywhere?
 };
-const activeTabDomain = computed(() => {
-  const { domain, hasSubdomain, subDomain } = checkDomain(activeTabHost.value);
-  return hasSubdomain ? subDomain : domain;
-});
-
 const useActiveTab = () => {
   getActiveTab();
 
-  return { activeTabDomain, activeTabHost, isAboutPage, isExtensionPage };
+  return { activeTabHost, isAboutPage, isExtensionPage };
 };
 
 export default useActiveTab;

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -304,7 +304,7 @@ const neverProxyHost = (host: string) => {
 };
 
 watch(
-  [globalProxyDetails, hostProxiesDetails],
+  [globalProxyDetails, hostProxiesDetails, excludedHosts],
   () => {
     checkStatus();
   },

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -49,13 +49,61 @@ const currentHostProxyDetails = computed(() => {
     return hostProxiesDetails.value[activeTabHost.value];
   }
 
+  // Also check parent domain for disabled configs (subdomain fallback)
+  if (hasSubdomain && hostProxiesDetails.value[domain]) {
+    return hostProxiesDetails.value[domain];
+  }
+
   return null;
 });
 
 const globalProxyEnabled = computed(() => globalProxyDetails.value.socksEnabled);
+
+const currentHostExcluded = computed(() => {
+  const { domain, hasSubdomain } = checkDomain(activeTabHost.value);
+  return (
+    excludedHosts.value.includes(activeTabHost.value) ||
+    (hasSubdomain && excludedHosts.value.includes(domain))
+  );
+});
+
 const currentHostProxyEnabled = computed(
-  () => currentHostProxyDetails.value?.socksEnabled ?? false,
+  () => !currentHostExcluded.value && (currentHostProxyDetails.value?.socksEnabled ?? false),
 );
+
+const currentEffectiveProxyDomain = computed(() => {
+  const { hasSubdomain, domain } = checkDomain(activeTabHost.value);
+
+  // If the host or its parent domain is excluded, return the excluded domain
+  if (excludedHosts.value.includes(activeTabHost.value)) {
+    return activeTabHost.value;
+  }
+  if (hasSubdomain && excludedHosts.value.includes(domain)) {
+    return domain;
+  }
+
+  // Then check for exact matches that are enabled
+  if (hostProxiesDetails.value[activeTabHost.value]?.socksEnabled) {
+    return activeTabHost.value;
+  }
+
+  // Then check parent domain if this is a subdomain (fallback)
+  if (hasSubdomain && hostProxiesDetails.value[domain]?.socksEnabled) {
+    return domain;
+  }
+
+  // Any existing proxy config for the exact host
+  if (hostProxiesDetails.value[activeTabHost.value]) {
+    return activeTabHost.value;
+  }
+
+  // Parent domain fallback for disabled configs
+  if (hasSubdomain && hostProxiesDetails.value[domain]) {
+    return domain;
+  }
+
+  return activeTabHost.value;
+});
 
 const globalProxyDNSEnabled = computed(() => globalProxy.value?.proxyDNS ?? false);
 const currentHostProxyDNSEnabled = computed(() => currentHostProxyDetails.value?.proxyDNS ?? false);
@@ -269,6 +317,8 @@ const useSocksProxy = () => {
     currentHostProxyDetails,
     currentHostProxyDNSEnabled,
     currentHostProxyEnabled,
+    currentHostExcluded,
+    currentEffectiveProxyDomain,
     excludedHosts,
     globalProxy,
     globalProxyDetails,

--- a/src/helpers/socksProxy/socksProxy.ts
+++ b/src/helpers/socksProxy/socksProxy.ts
@@ -28,9 +28,12 @@ export const handleProxyRequest = async (details: browser.proxy._OnRequestDetail
     const { hasSubdomain, domain, subDomain } = checkDomain(currentHost);
     const currentDomain = hasSubdomain ? subDomain : domain;
 
-    const isDomainExcluded = excludedHosts.includes(currentDomain);
+    const isDomainExcluded =
+      excludedHosts.includes(currentDomain) || (hasSubdomain && excludedHosts.includes(domain));
     const isDomainProxied = Object.hasOwn(hostProxies, currentDomain);
     const isDomainProxydEnabled = Boolean(hostProxiesDetails[currentDomain]?.socksEnabled);
+    const isParentDomainProxied = hasSubdomain && Object.hasOwn(hostProxies, domain);
+    const isParentProxyEnabled = hasSubdomain && Boolean(hostProxiesDetails[domain]?.socksEnabled);
     const isGlobalProxyEnabled = globalProxyDetails.socksEnabled;
 
     // 1. Block speculative requests, since we can't identify their origins
@@ -69,6 +72,11 @@ export const handleProxyRequest = async (details: browser.proxy._OnRequestDetail
 
     if (isDomainProxied && isDomainProxydEnabled) {
       return hostProxies[currentDomain];
+    }
+
+    // 5b. Fallback to parent domain for subdomains (e.g., www.reddit.com -> reddit.com)
+    if (isParentDomainProxied && isParentProxyEnabled) {
+      return hostProxies[domain];
     }
 
     // 6. Check global proxy
@@ -175,9 +183,12 @@ const getProxyForExtensionConnectionCheck = async (
   const { domain, hasSubdomain, subDomain } = checkDomain(host);
   const tabDomain = hasSubdomain ? subDomain : domain;
 
-  const isTabDomainExcluded = excludedHosts.includes(tabDomain);
+  const isTabDomainExcluded =
+    excludedHosts.includes(tabDomain) || (hasSubdomain && excludedHosts.includes(domain));
   const isTabDomainProxied = Object.hasOwn(hostProxies, tabDomain);
   const isTabProxyEnabled = !!hostProxiesDetails[tabDomain]?.socksEnabled;
+  const isParentDomainProxied = hasSubdomain && Object.hasOwn(hostProxies, domain);
+  const isParentProxyEnabled = hasSubdomain && !!hostProxiesDetails[domain]?.socksEnabled;
 
   // a) If the current tab is an about page, we only need to check for a global proxy
   if (isAboutPage) {
@@ -197,6 +208,11 @@ const getProxyForExtensionConnectionCheck = async (
   // d) If current tab is proxied, we need to check for the current tab's proxy
   if (isTabDomainProxied && isTabProxyEnabled) {
     return hostProxies[tabDomain];
+  }
+
+  // d-b) Fallback to parent domain for subdomains (e.g., www.reddit.com -> reddit.com)
+  if (isParentDomainProxied && isParentProxyEnabled) {
+    return hostProxies[domain];
   }
 
   // e) If global proxy is enabled

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -20,10 +20,12 @@ const {
   dnsServers,
 } = useCheckDnsLeaks();
 const { randomProxyMode } = useRandomProxy();
-const { globalProxyEnabled, currentHostProxyEnabled } = useSocksProxy();
+const { globalProxyEnabled, currentHostProxyEnabled, currentHostExcluded } = useSocksProxy();
 
 const isProxyInUse = computed(
-  () => !!(randomProxyMode.value || currentHostProxyEnabled.value || globalProxyEnabled.value),
+  () =>
+    !currentHostExcluded.value &&
+    !!(randomProxyMode.value || currentHostProxyEnabled.value || globalProxyEnabled.value),
 );
 </script>
 


### PR DESCRIPTION
When a proxy was configured for a parent domain (e.g., `reddit.com`), visiting a subdomain (e.g., `www.reddit.com`) would not use that proxy.

The UI needed update in multiple places to show the correct behavior of the effective proxy.

The proxy status has been fixed, alongside the proxies toggle based on which proxy config is "in use" .