### PR TITLE
Rely on tldts to recognize special use domains

### DIFF
--- a/src/helpers/domain.ts
+++ b/src/helpers/domain.ts
@@ -10,14 +10,10 @@ export const checkDomain = (host: string) => {
 };
 
 export const isValidDomain = (domain: string): boolean => {
-  // Special use domains should be allowed according to the IETF RFC 6761
-  const publicSuffixes = ['arpa', 'test', 'localhost', 'internal'];
+  // Handle special-use domains (localhost, test, invalid, example, local, onion, alt and home.arpa)
+  const parsed = parse(domain, { detectSpecialUse: true });
 
-  const parsed = parse(domain, {
-    validHosts: publicSuffixes,
-  });
-
-  return Boolean(parsed.domain && (parsed.isIcann || publicSuffixes.includes(parsed.domain)));
+  return Boolean(parsed.isSpecialUse || (parsed.domain && parsed.isIcann));
 };
 
 export const normalizeToFQDN = (input: string): string | null => {

--- a/src/helpers/domains.test.ts
+++ b/src/helpers/domains.test.ts
@@ -30,6 +30,7 @@ describe('domain helpers', () => {
     it('should return false for invalid domains', () => {
       expect(isValidDomain('not-a-domain')).toBe(false);
       expect(isValidDomain('not-a-domain.blabla')).toBe(false);
+      expect(isValidDomain('.not-a-domain')).toBe(false);
       expect(isValidDomain('')).toBe(false);
     });
 
@@ -37,7 +38,16 @@ describe('domain helpers', () => {
       expect(isValidDomain('home.arpa')).toBe(true);
       expect(isValidDomain('example.test')).toBe(true);
       expect(isValidDomain('server.localhost')).toBe(true);
-      expect(isValidDomain('page.internal')).toBe(true);
+      expect(isValidDomain('printer.local')).toBe(true);
+      expect(isValidDomain('example.onion')).toBe(true);
+      expect(isValidDomain('foo.alt')).toBe(true);
+      expect(isValidDomain('example.invalid')).toBe(true);
+      expect(isValidDomain('www.example.com')).toBe(true);
+    });
+
+    it('should return false for bare public suffixes', () => {
+      expect(isValidDomain('com')).toBe(false);
+      expect(isValidDomain('net')).toBe(false);
     });
   });
 


### PR DESCRIPTION
Previously hardcoded special use domains detection now uses the tldts library.