### PR TITLE
Fix storage composable and workarounds

### DIFF
--- a/src/components/ImportExport/Export.vue
+++ b/src/components/ImportExport/Export.vue
@@ -5,7 +5,10 @@ import { NButton, NCard, NFlex } from 'naive-ui';
 import MuSpinner from '@/components/Icons/MuSpinner.vue';
 import TitleCategory from '@/components/TitleCategory.vue';
 
-import useSocksProxy from '@/composables/useSocksProxy';
+import useStore from '@/composables/useStore';
+
+const { excludedHosts, globalProxy, globalProxyDetails, hostProxies, hostProxiesDetails } =
+  useStore();
 
 const href = ref('');
 
@@ -16,9 +19,6 @@ const href = ref('');
  * which would require additional permissions.
  */
 const setupExport = async () => {
-  const { excludedHosts, globalProxy, globalProxyDetails, hostProxies, hostProxiesDetails } =
-    useSocksProxy();
-
   const data = {
     excludedHosts: excludedHosts.value,
     globalProxy: globalProxy.value,

--- a/src/components/ImportExport/Import.vue
+++ b/src/components/ImportExport/Import.vue
@@ -4,12 +4,11 @@ import { NButton, NCard, NIcon } from 'naive-ui';
 
 import TitleCategory from '@/components/TitleCategory.vue';
 
-import useSocksProxy from '@/composables/useSocksProxy';
+import useStore from '@/composables/useStore';
 import FeWarning from '@/components/Icons/FeWarning.vue';
 
-// CustomProxies.vue uses useSocksProxy, so use that here too to ensure reactivity
 const { excludedHosts, globalProxy, globalProxyDetails, hostProxies, hostProxiesDetails } =
-  useSocksProxy();
+  useStore();
 
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const message = ref<string>('');

--- a/src/components/Proxy/CustomProxies.vue
+++ b/src/components/Proxy/CustomProxies.vue
@@ -22,17 +22,14 @@ import { isValidDomain, normalizeToFQDN } from '@/helpers/domain';
 
 import useSocksProxy from '@/composables/useSocksProxy';
 import useLocations from '@/composables/useLocations';
+import useStore from '@/composables/useStore';
 
 const { proxySelect } = useLocations();
+const { excludedHosts, globalProxyDetails, hostProxiesDetails } = useStore();
 
-// For some reason importing `hostProxiesDetails` directly from useStore()
-// will cause the value not to be reactively updated
 const {
   allowProxy,
-  excludedHosts,
-  globalProxyDetails,
   globalProxyEnabled,
-  hostProxiesDetails,
   neverProxyHost,
   removeCustomProxy,
   removeGlobalProxy,

--- a/src/components/Proxy/PopupProxyPanel.vue
+++ b/src/components/Proxy/PopupProxyPanel.vue
@@ -31,7 +31,6 @@ const {
   currentHostExcluded,
   currentEffectiveProxyHost,
   globalProxyEnabled,
-  globalProxyDetails,
   neverProxyHost,
   removeCustomProxy,
   removeGlobalProxy,
@@ -41,7 +40,7 @@ const {
 import useSocksProxies from '@/composables/useSocksProxies';
 import useStore from '@/composables/useStore';
 
-const { flatProxiesList } = useStore();
+const { flatProxiesList, globalProxyDetails } = useStore();
 const { getSocksProxies } = useSocksProxies();
 
 const isCurrentHostProxyOverriden = computed(() => randomProxyMode.value);

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -105,9 +105,6 @@ const currentEffectiveProxyHost = computed(() => {
   return activeTabHost.value;
 });
 
-const globalProxyDNSEnabled = computed(() => globalProxy.value?.proxyDNS ?? false);
-const currentHostProxyDNSEnabled = computed(() => currentHostProxyDetails.value?.proxyDNS ?? false);
-
 const combinedHosts = computed(() => {
   // hosts that are excluded from proxying + hosts that enabled for proxying
   const enabledProxyHosts = Object.entries(hostProxiesDetails.value)
@@ -122,33 +119,6 @@ const toggleGlobalProxy = () => {
   reloadOptions();
   if (proxyAutoReload.value) {
     reloadGlobalProxiedTabs(combinedHosts.value);
-  }
-  updateCurrentTabProxyBadge();
-};
-
-const toggleSubDomainProxy = (subdomain: string) => {
-  const { domain } = checkDomain(subdomain);
-
-  // If no subdomain proxy exists but parent domain has proxy
-  if (!hostProxiesDetails.value[subdomain] && hostProxiesDetails.value[domain]) {
-    // Clone parent domain proxy settings
-    hostProxiesDetails.value[subdomain] = {
-      ...hostProxiesDetails.value[domain],
-      socksEnabled: true,
-    };
-    hostProxies.value[subdomain] = {
-      ...hostProxies.value[domain],
-      proxyDNS: hostProxiesDetails.value[domain].proxyDNS,
-    };
-  } else {
-    // Toggle existing subdomain proxy
-    hostProxiesDetails.value[subdomain].socksEnabled =
-      !hostProxiesDetails.value[subdomain].socksEnabled;
-  }
-
-  reloadOptions();
-  if (proxyAutoReload.value) {
-    reloadMatchingTabs(subdomain);
   }
   updateCurrentTabProxyBadge();
 };
@@ -315,24 +285,16 @@ const useSocksProxy = () => {
   return {
     allowProxy,
     currentHostProxyDetails,
-    currentHostProxyDNSEnabled,
     currentHostProxyEnabled,
     currentHostExcluded,
     currentEffectiveProxyHost,
-    excludedHosts,
-    globalProxy,
-    globalProxyDetails,
-    globalProxyDNSEnabled,
     globalProxyEnabled,
-    hostProxies,
-    hostProxiesDetails,
     neverProxyHost,
     removeCustomProxy,
     removeGlobalProxy,
     setCustomProxy,
     setGlobalProxy,
     toggleHostProxy,
-    toggleSubDomainProxy,
     toggleCustomProxy,
     toggleCustomProxyDNS,
     toggleGlobalProxy,

--- a/src/composables/useStore.ts
+++ b/src/composables/useStore.ts
@@ -10,22 +10,22 @@ import useBrowserStorageLocal from '@/composables/useBrowserStorageLocal';
 import { SocksProxy } from '@/helpers/socksProxy/socksProxies.types';
 import { HistoryEntriesMap } from '@/composables/useProxyHistory/HistoryEntries.types';
 
-const useStore = () => {
-  const excludedHosts = useBrowserStorageLocal<string[]>('excludedHosts', []);
-  const flatProxiesList = useBrowserStorageLocal<SocksProxy[]>('flatProxiesList', []);
-  const globalProxy = useBrowserStorageLocal<ProxyInfo>('globalProxy', {} as ProxyInfo);
-  const globalProxyDetails = useBrowserStorageLocal<ProxyDetails>(
-    'globalProxyDetails',
-    {} as ProxyDetails,
-  );
-  const historyEntries = useBrowserStorageLocal<HistoryEntriesMap>('historyEntries', {});
-  const hostProxies = useBrowserStorageLocal<ProxyInfoMap>('hostProxies', {});
-  const hostProxiesDetails = useBrowserStorageLocal<ProxyDetailsMap>('hostProxiesDetails', {});
-  const optionsActiveTab = useBrowserStorageLocal<Tab>('optionsActiveTab', Tab.SETTINGS);
-  const proxyAutoReload = useBrowserStorageLocal('proxyAutoReload', false);
-  const randomProxyMode = useBrowserStorageLocal('randomProxyMode', false);
-  const webRTCStatus = useBrowserStorageLocal('webRTCStatus', true);
+const excludedHosts = useBrowserStorageLocal<string[]>('excludedHosts', []);
+const flatProxiesList = useBrowserStorageLocal<SocksProxy[]>('flatProxiesList', []);
+const globalProxy = useBrowserStorageLocal<ProxyInfo>('globalProxy', {} as ProxyInfo);
+const globalProxyDetails = useBrowserStorageLocal<ProxyDetails>(
+  'globalProxyDetails',
+  {} as ProxyDetails,
+);
+const historyEntries = useBrowserStorageLocal<HistoryEntriesMap>('historyEntries', {});
+const hostProxies = useBrowserStorageLocal<ProxyInfoMap>('hostProxies', {});
+const hostProxiesDetails = useBrowserStorageLocal<ProxyDetailsMap>('hostProxiesDetails', {});
+const optionsActiveTab = useBrowserStorageLocal<Tab>('optionsActiveTab', Tab.SETTINGS);
+const proxyAutoReload = useBrowserStorageLocal('proxyAutoReload', false);
+const randomProxyMode = useBrowserStorageLocal('randomProxyMode', false);
+const webRTCStatus = useBrowserStorageLocal('webRTCStatus', true);
 
+const useStore = () => {
   return {
     excludedHosts,
     flatProxiesList,


### PR DESCRIPTION
useStore was creating fresh storage refs on every call, causing divergent state between components in the same context. Workarounds have now been removed.

Some dead code has also been removed:
- toggleSubDomainProxy
- globalProxyDNSEnabled
- currentHostProxyDNSEnabled