### PR TITLE
Refactor conncheck proxy

### DIFF
--- a/src/composables/useConnection/useCheckDnsLeaks.ts
+++ b/src/composables/useConnection/useCheckDnsLeaks.ts
@@ -37,23 +37,18 @@ const isMullvadDoh = ref(false);
 
 const { isError: isConnectionError } = useConnection();
 
+// Watch for connection errors and abort DNS leak check if needed.
+watch(isConnectionError, (newValue) => {
+  if (newValue && isLoading.value) {
+    // Connection error occurred during DNS leak check
+    isLoading.value = false;
+    isError.value = true;
+    error.value = new Error('Connection error detected, aborting DNS leak check');
+  }
+});
+
 const useCheckDnsLeaks = () => {
-  // Watch for connection errors and abort DNS leak check if needed
-  watch(isConnectionError, (newValue) => {
-    if (newValue && isLoading.value) {
-      // Connection error occurred during DNS leak check
-      isLoading.value = false;
-      isError.value = true;
-      error.value = new Error('Connection error detected, aborting DNS leak check');
-    }
-  });
-
   const checkDnsLeaks = async () => {
-    if (isLoading.value) {
-      console.log('DNS leak check already in progress, skipping');
-      return;
-    }
-
     dnsServers.value = [];
     error.value = undefined;
     isError.value = false;
@@ -85,11 +80,6 @@ const useCheckDnsLeaks = () => {
       isLoading.value = false;
     }
   };
-
-  // Don't start multiple checks
-  if (!isLoading.value) {
-    checkDnsLeaks();
-  }
 
   return {
     checkDnsLeaks,

--- a/src/composables/useConnection/useConnection.ts
+++ b/src/composables/useConnection/useConnection.ts
@@ -2,47 +2,41 @@ import { InjectionKey, Ref, ref } from 'vue';
 import type { Connection } from '@/helpers/connCheck.types';
 import { connCheckIpv4, connCheckIpv6 } from '@/helpers/connCheck';
 
-//  Keep this outside of the hook to make it a singleton
 const connection = ref({} as Connection);
 const isLoading = ref(false);
 const isError = ref(false);
 const error = ref<Error | undefined>(undefined);
 
-const useConnection = () => {
-  const updateConnection = async () => {
-    isLoading.value = true;
-    isError.value = false;
-    error.value = undefined;
-    try {
-      const ipv4Promise = connCheckIpv4();
-      const ipv6Promise = connCheckIpv6();
+const updateConnection = async () => {
+  isLoading.value = true;
+  isError.value = false;
+  error.value = undefined;
+  try {
+    const ipv4Promise = connCheckIpv4();
+    const ipv6Promise = connCheckIpv6();
 
-      // Wait for IPv4 result
-      connection.value = await ipv4Promise;
+    // Wait for IPv4 result
+    connection.value = await ipv4Promise;
 
-      // Because IPV6 is not reliably working in socks proxy,
-      // don't wait IPv6 result so that it's non-blocking.
-      ipv6Promise
-        .then((ipv6) => {
-          connection.value = { ...connection.value, ipv6 };
-        })
-        .catch((e) => {
-          console.log(`IPv6 check error: ${e.message}`);
-        });
-    } catch (e) {
-      console.log({ useConnectionError: e });
-      isError.value = true;
-      error.value = e as Error;
-    } finally {
-      isLoading.value = false;
-    }
-  };
-
-  // Don't run multiple checks at the same time
-  if (!isLoading.value) {
-    updateConnection();
+    // Because IPV6 is not reliably working in socks proxy,
+    // don't wait IPv6 result so that it's non-blocking.
+    ipv6Promise
+      .then((ipv6) => {
+        connection.value = { ...connection.value, ipv6 };
+      })
+      .catch((e) => {
+        console.log(`IPv6 check error: ${e.message}`);
+      });
+  } catch (e) {
+    console.log({ useConnectionError: e });
+    isError.value = true;
+    error.value = e as Error;
+  } finally {
+    isLoading.value = false;
   }
+};
 
+const useConnection = () => {
   return { connection, error, isError, isLoading, updateConnection };
 };
 

--- a/src/composables/useConnection/useConnection.ts
+++ b/src/composables/useConnection/useConnection.ts
@@ -12,21 +12,9 @@ const updateConnection = async () => {
   isError.value = false;
   error.value = undefined;
   try {
-    const ipv4Promise = connCheckIpv4();
-    const ipv6Promise = connCheckIpv6();
+    const [ipv4Result, ipv6Result] = await Promise.all([connCheckIpv4(), connCheckIpv6()]);
 
-    // Wait for IPv4 result
-    connection.value = await ipv4Promise;
-
-    // Because IPV6 is not reliably working in socks proxy,
-    // don't wait IPv6 result so that it's non-blocking.
-    ipv6Promise
-      .then((ipv6) => {
-        connection.value = { ...connection.value, ipv6 };
-      })
-      .catch((e) => {
-        console.log(`IPv6 check error: ${e.message}`);
-      });
+    connection.value = { ...ipv4Result, ipv6: ipv6Result };
   } catch (e) {
     console.log({ useConnectionError: e });
     isError.value = true;

--- a/src/composables/useConnection/useConnectionStatus.ts
+++ b/src/composables/useConnection/useConnectionStatus.ts
@@ -6,7 +6,7 @@ const isChecking = ref(false);
 
 const useConnectionStatus = () => {
   const { updateConnection, isError } = useConnection();
-  const { checkDnsLeaks } = useCheckDnsLeaks();
+  const { checkDnsLeaks, isLoading: dnsIsLoading } = useCheckDnsLeaks();
 
   const checkStatus = async () => {
     if (isChecking.value) {
@@ -15,12 +15,16 @@ const useConnectionStatus = () => {
     }
 
     isChecking.value = true;
+    // Show DNS spinner for the entire duration (connection check + DNS check)
+    dnsIsLoading.value = true;
 
     try {
       await updateConnection();
 
       if (!isError.value) {
         await checkDnsLeaks();
+      } else {
+        dnsIsLoading.value = false;
       }
     } finally {
       isChecking.value = false;

--- a/src/composables/useConnection/useConnectionStatus.ts
+++ b/src/composables/useConnection/useConnectionStatus.ts
@@ -10,7 +10,6 @@ const useConnectionStatus = () => {
 
   const checkStatus = async () => {
     if (isChecking.value) {
-      console.log('Status check already in progress, skipping');
       return;
     }
 

--- a/src/composables/useConnection/useConnectionStatus.ts
+++ b/src/composables/useConnection/useConnectionStatus.ts
@@ -4,12 +4,11 @@ import useCheckDnsLeaks from '@/composables/useConnection/useCheckDnsLeaks';
 
 const isChecking = ref(false);
 
-export default function useConnectionStatus() {
+const useConnectionStatus = () => {
   const { updateConnection, isError } = useConnection();
   const { checkDnsLeaks } = useCheckDnsLeaks();
 
   const checkStatus = async () => {
-    // Prevent multiple simultaneous checks
     if (isChecking.value) {
       console.log('Status check already in progress, skipping');
       return;
@@ -32,4 +31,6 @@ export default function useConnectionStatus() {
     checkStatus,
     isChecking,
   };
-}
+};
+
+export default useConnectionStatus;

--- a/src/composables/useRandomProxy.ts
+++ b/src/composables/useRandomProxy.ts
@@ -1,5 +1,3 @@
-import { watch } from 'vue';
-
 import { updateCurrentTabProxyBadge } from '@/helpers/proxyBadge';
 
 import useStore from '@/composables/useStore';
@@ -12,11 +10,8 @@ const useRandomProxy = () => {
   const toggleRandomProxyMode = () => {
     randomProxyMode.value = !randomProxyMode.value;
     updateCurrentTabProxyBadge();
-  };
-
-  watch(randomProxyMode, () => {
     checkStatus();
-  });
+  };
 
   return {
     toggleRandomProxyMode,

--- a/src/composables/useRandomProxy.ts
+++ b/src/composables/useRandomProxy.ts
@@ -14,13 +14,9 @@ const useRandomProxy = () => {
     updateCurrentTabProxyBadge();
   };
 
-  watch(
-    randomProxyMode,
-    () => {
-      checkStatus();
-    },
-    { deep: true, immediate: false },
-  );
+  watch(randomProxyMode, () => {
+    checkStatus();
+  });
 
   return {
     toggleRandomProxyMode,

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -275,13 +275,9 @@ const neverProxyHost = (host: string) => {
   }
 };
 
-watch(
-  [globalProxyDetails, hostProxiesDetails, excludedHosts],
-  () => {
-    checkStatus();
-  },
-  { deep: true, immediate: false },
-);
+watch([globalProxyDetails, hostProxiesDetails, excludedHosts], () => {
+  checkStatus();
+});
 
 const useSocksProxy = () => {
   return {

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -31,8 +31,10 @@ const {
   proxyAutoReload,
 } = useStore();
 
+const activeTabDomainInfo = computed(() => checkDomain(activeTabHost.value));
+
 const currentHostProxyDetails = computed(() => {
-  const { hasSubdomain, domain } = checkDomain(activeTabHost.value);
+  const { hasSubdomain, domain } = activeTabDomainInfo.value;
 
   // First check for exact matches that are enabled
   if (hostProxiesDetails.value[activeTabHost.value]?.socksEnabled) {
@@ -60,7 +62,7 @@ const currentHostProxyDetails = computed(() => {
 const globalProxyEnabled = computed(() => globalProxyDetails.value.socksEnabled);
 
 const currentHostExcluded = computed(() => {
-  const { domain, hasSubdomain } = checkDomain(activeTabHost.value);
+  const { domain, hasSubdomain } = activeTabDomainInfo.value;
   return (
     excludedHosts.value.includes(activeTabHost.value) ||
     (hasSubdomain && excludedHosts.value.includes(domain))
@@ -72,7 +74,7 @@ const currentHostProxyEnabled = computed(
 );
 
 const currentEffectiveProxyHost = computed(() => {
-  const { hasSubdomain, domain } = checkDomain(activeTabHost.value);
+  const { hasSubdomain, domain } = activeTabDomainInfo.value;
 
   // If the host or its parent domain is excluded, return the excluded domain
   if (excludedHosts.value.includes(activeTabHost.value)) {

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -1,4 +1,4 @@
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 
 import {
   ProxyDetails,
@@ -123,6 +123,7 @@ const toggleGlobalProxy = () => {
     reloadGlobalProxiedTabs(combinedHosts.value);
   }
   updateCurrentTabProxyBadge();
+  checkStatus();
 };
 
 const toggleHostProxy = (host: string) => {
@@ -132,6 +133,7 @@ const toggleHostProxy = (host: string) => {
     reloadMatchingTabs(host);
   }
   updateCurrentTabProxyBadge();
+  checkStatus();
 };
 
 const toggleCustomProxy = (host: string) => {
@@ -143,6 +145,7 @@ const toggleCustomProxy = (host: string) => {
     reloadMatchingTabs(targetHost);
   }
   updateCurrentTabProxyBadge();
+  checkStatus();
 };
 
 const toggleCustomProxyDNS = (host: string) => {
@@ -156,6 +159,7 @@ const toggleCustomProxyDNS = (host: string) => {
   if (proxyAutoReload.value) {
     reloadMatchingTabs(targetHost);
   }
+  checkStatus();
 };
 
 const toggleGlobalProxyDNS = () => {
@@ -166,6 +170,7 @@ const toggleGlobalProxyDNS = () => {
     reloadGlobalProxiedTabs(combinedHosts.value);
   }
   updateCurrentTabProxyBadge();
+  checkStatus();
 };
 
 const setGlobalProxy = ({
@@ -199,6 +204,7 @@ const setGlobalProxy = ({
   if (proxyAutoReload.value) {
     reloadGlobalProxiedTabs(combinedHosts.value);
   }
+  checkStatus();
 };
 
 const setCustomProxy = (
@@ -235,6 +241,7 @@ const setCustomProxy = (
   if (proxyAutoReload.value) {
     reloadMatchingTabs(host);
   }
+  checkStatus();
 };
 
 const removeCustomProxy = (host: string) => {
@@ -245,6 +252,7 @@ const removeCustomProxy = (host: string) => {
   if (proxyAutoReload.value) {
     reloadMatchingTabs(host);
   }
+  checkStatus();
 };
 
 const removeGlobalProxy = () => {
@@ -255,6 +263,7 @@ const removeGlobalProxy = () => {
   if (proxyAutoReload.value) {
     reloadGlobalProxiedTabs(combinedHosts.value);
   }
+  checkStatus();
 };
 
 const allowProxy = (host: string) => {
@@ -264,6 +273,7 @@ const allowProxy = (host: string) => {
   if (proxyAutoReload.value) {
     reloadMatchingTabs(host);
   }
+  checkStatus();
 };
 
 const neverProxyHost = (host: string) => {
@@ -273,11 +283,8 @@ const neverProxyHost = (host: string) => {
   if (proxyAutoReload.value) {
     reloadMatchingTabs(host);
   }
-};
-
-watch([globalProxyDetails, hostProxiesDetails, excludedHosts], () => {
   checkStatus();
-});
+};
 
 const useSocksProxy = () => {
   return {

--- a/src/helpers/domain.ts
+++ b/src/helpers/domain.ts
@@ -1,7 +1,7 @@
 import { parse } from 'tldts';
 
 export const checkDomain = (host: string) => {
-  const parsed = parse(host);
+  const parsed = parse(host, { detectSpecialUse: true });
   return {
     hasSubdomain: Boolean(parsed.subdomain),
     fullHost: host,

--- a/src/helpers/domains.test.ts
+++ b/src/helpers/domains.test.ts
@@ -19,6 +19,41 @@ describe('domain helpers', () => {
         domain: 'torproject.org',
       });
     });
+
+    it('should detect subdomain in special-use domains', () => {
+      expect(checkDomain('api.myapp.test')).toEqual({
+        hasSubdomain: true,
+        fullHost: 'api.myapp.test',
+        domain: 'myapp.test',
+      });
+      expect(checkDomain('sub.example.test')).toEqual({
+        hasSubdomain: true,
+        fullHost: 'sub.example.test',
+        domain: 'example.test',
+      });
+    });
+
+    it('should handle special-use domains without subdomain', () => {
+      expect(checkDomain('printer.local')).toEqual({
+        hasSubdomain: false,
+        fullHost: 'printer.local',
+        domain: 'printer.local',
+      });
+      expect(checkDomain('myapp.test')).toEqual({
+        hasSubdomain: false,
+        fullHost: 'myapp.test',
+        domain: 'myapp.test',
+      });
+    });
+
+    it('should treat onion addresses as atomic (no subdomain)', () => {
+      const onion = 'abcdefghijklmnop.onion';
+      expect(checkDomain(onion)).toEqual({
+        hasSubdomain: false,
+        fullHost: onion,
+        domain: onion,
+      });
+    });
   });
 
   describe('isValidDomain', () => {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,13 +1,21 @@
 <script lang="ts" setup>
-import { provide } from 'vue';
+import { onMounted, provide } from 'vue';
 import { NConfigProvider, darkTheme } from 'naive-ui';
 
 import Popup from '@/popup/Popup.vue';
 import { themeOverrides } from '@/styles/themeOverrides';
+
 import useConnection, { ConnectionKey } from '@/composables/useConnection/useConnection';
+import useConnectionStatus from '@/composables/useConnection/useConnectionStatus';
 
 const { isLoading, connection, isError } = useConnection();
+const { checkStatus } = useConnectionStatus();
+
 provide(ConnectionKey, { connection, isLoading, isError });
+
+onMounted(() => {
+  void checkStatus();
+});
 </script>
 
 <template>


### PR DESCRIPTION
Closes #320 

It's been a while I've been meaning to refactor the way the connection check are made, because I noticed there was a lot extra unwanted calls.

Most of it is not using watchers properly, or without thinking of side-effects and a rethink about where to put guards, to prevent executing connchecks multiple times.