### PR TITLE
Refactor reactivity in relation to fetching proxy list

### DIFF
--- a/src/components/Proxy/PopupProxyPanel.vue
+++ b/src/components/Proxy/PopupProxyPanel.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, ref, watchEffect } from 'vue';
 import { NCard, NCollapseTransition, NIcon, NSwitch, NTag } from 'naive-ui';
 
 import Button from '@/components/Buttons/Button.vue';
@@ -22,7 +22,7 @@ const showDetailsRandom = ref(false);
 
 const { isAboutPage, isExtensionPage } = useActiveTab();
 const { proxySelect } = useLocations();
-const { isGranted, requestPermissions } = useProxyPermissions();
+const { isGranted, checkProxyPermissions, requestPermissions } = useProxyPermissions();
 const { toggleRandomProxyMode, randomProxyMode } = useRandomProxy();
 const {
   allowProxy,
@@ -40,7 +40,7 @@ const {
 import useSocksProxies from '@/composables/useSocksProxies';
 import useStore from '@/composables/useStore';
 
-const { flatProxiesList, globalProxyDetails } = useStore();
+const { globalProxyDetails } = useStore();
 const { getSocksProxies } = useSocksProxies();
 
 const isCurrentHostProxyOverriden = computed(() => randomProxyMode.value);
@@ -51,9 +51,12 @@ const isAllWebsitesProxyOverriden = computed(() =>
     : true,
 );
 
-watch(isGranted, (newValue) => {
-  // If permissions are granted and proxies list is empty
-  if (newValue && (!flatProxiesList.value || flatProxiesList.value.length === 0)) {
+onMounted(() => {
+  checkProxyPermissions();
+});
+
+watchEffect(() => {
+  if (isGranted.value) {
     getSocksProxies();
   }
 });

--- a/src/composables/useProxyPermissions.ts
+++ b/src/composables/useProxyPermissions.ts
@@ -1,22 +1,21 @@
 import { ref, readonly } from 'vue';
 import { getProxyPermissions, requestProxyPermissions } from '@/helpers/permissions';
 
+const isGranted = ref(false);
+
+const checkProxyPermissions = async () => {
+  isGranted.value = await getProxyPermissions();
+};
+
+const requestPermissions = async (): Promise<boolean> => {
+  isGranted.value = await requestProxyPermissions();
+  return isGranted.value;
+};
+
 const useProxyPermissions = () => {
-  const isGranted = ref(false);
-
-  const checkProxyPermissions = async () => {
-    isGranted.value = await getProxyPermissions();
-  };
-
-  const requestPermissions = async (): Promise<boolean> => {
-    isGranted.value = await requestProxyPermissions();
-    return isGranted.value;
-  };
-
-  checkProxyPermissions();
-
   return {
     isGranted: readonly(isGranted),
+    checkProxyPermissions,
     requestPermissions,
   };
 };

--- a/src/composables/useSocksProxies.ts
+++ b/src/composables/useSocksProxies.ts
@@ -20,58 +20,54 @@ const clearFilter = () => {
   query.value = '';
 };
 
-const useSocksProxies = () => {
-  const getSocksProxies = async () => {
-    isLoading.value = true;
-    isError.value = false;
-    error.value = '';
+const getSocksProxies = async () => {
+  isLoading.value = true;
+  isError.value = false;
+  error.value = '';
 
-    try {
-      const response = await fetch(SOCKS_API_URL);
-      const data: SocksProxy[] = await response.json();
-      flatProxiesList.value = data.filter((proxy: SocksProxy) => {
-        return proxy.online && proxy.ipv4_address && proxy.hostname;
-      });
-    } catch (e: unknown) {
-      isError.value = true;
+  try {
+    const response = await fetch(SOCKS_API_URL);
+    const data: SocksProxy[] = await response.json();
+    flatProxiesList.value = data.filter((proxy: SocksProxy) => {
+      return proxy.online && proxy.ipv4_address && proxy.hostname;
+    });
+  } catch (e: unknown) {
+    isError.value = true;
 
-      if (e instanceof Error) {
-        if (e.message.includes('NetworkError')) {
-          error.value = NETWORK_ERROR;
-        } else {
-          error.value = e.message;
-        }
+    if (e instanceof Error) {
+      if (e.message.includes('NetworkError')) {
+        error.value = NETWORK_ERROR;
       } else {
-        error.value = `An unknown error occurred: ${e}`;
+        error.value = e.message;
       }
-      console.log(e);
-    } finally {
-      isLoading.value = false;
+    } else {
+      error.value = `An unknown error occurred: ${e}`;
     }
-  };
-
-  const queryLower = computed(() => query.value?.toLowerCase() ?? '');
-  const filteredData = computed(() =>
-    flatProxiesList.value.filter((socksProxy) => {
-      const q = queryLower.value;
-      if (!q) return true;
-
-      const country = socksProxy.location.country?.toLowerCase();
-      const city = socksProxy.location.city?.toLowerCase();
-      const hostname = socksProxy.hostname?.toLowerCase();
-
-      return country?.includes(q) || city?.includes(q) || hostname?.includes(q);
-    }),
-  );
-
-  const filteredProxies = computed(() =>
-    sortProxiesByCountryAndCity(groupByCountryAndCity(addCountryCode(filteredData.value))),
-  );
-
-  if (!isLoading.value) {
-    getSocksProxies();
+    console.log(e);
+  } finally {
+    isLoading.value = false;
   }
+};
 
+const queryLower = computed(() => query.value?.toLowerCase() ?? '');
+const filteredData = computed(() =>
+  flatProxiesList.value.filter((socksProxy) => {
+    const q = queryLower.value;
+    if (!q) return true;
+
+    const country = socksProxy.location.country?.toLowerCase();
+    const city = socksProxy.location.city?.toLowerCase();
+    const hostname = socksProxy.hostname?.toLowerCase();
+
+    return country?.includes(q) || city?.includes(q) || hostname?.includes(q);
+  }),
+);
+
+const filteredProxies = computed(() =>
+  sortProxiesByCountryAndCity(groupByCountryAndCity(addCountryCode(filteredData.value))),
+);
+
+const useSocksProxies = () => {
   return { clearFilter, filteredProxies, getSocksProxies, query, isLoading, isError, error };
 };
 


### PR DESCRIPTION
We want to fetch proxies every time we load the popup when proxy functionality is in use (so when the permissions have been given). Cleaning up the unwanted side-effects: keep reactivity at module level and trigger from the component explicitly.