### PR TITLE
Show full server info for frequent and recent locations

### DIFF
--- a/src/components/Buttons/Button.vue
+++ b/src/components/Buttons/Button.vue
@@ -1,40 +1,48 @@
 <script lang="ts" setup>
-import { computed, toRefs } from 'vue';
+import { computed } from 'vue';
 
 type Props = {
   color?: string;
   textColor?: string;
   href?: string;
   size?: 'small' | 'medium' | 'large';
+  whitespace?: 'nowrap' | 'normal';
 };
 
-const props = defineProps<Props>();
+// In Vue 3.5 and above, variables destructured from the return value of defineProps are reactive.
+const {
+  href = undefined,
+  color = undefined,
+  textColor = undefined,
+  size = undefined,
+  whitespace = 'nowrap',
+} = defineProps<Props>();
+
 const type = computed(() => {
-  if (props.href) {
+  if (href) {
     return 'a';
   }
   return 'button';
 });
 
-const { color, textColor } = toRefs(props);
 const classes = computed(() => {
   let colors = '';
   let sizeClass = '';
 
-  if (color?.value) {
-    colors = `bg-${color.value} text-${textColor?.value || 'white'}`;
+  if (color) {
+    colors = `bg-${color} text-${textColor || 'white'}`;
   }
 
-  if (props.size) {
-    sizeClass = `btn-${props.size}`;
+  if (size) {
+    sizeClass = `btn-${size}`;
   }
 
-  return `${colors} ${sizeClass}`;
+  return `whitespace-${whitespace} ${colors} ${sizeClass}`;
 });
 </script>
 
 <template>
-  <component :is="type" :href="href" class="btn whitespace-nowrap" :class="classes">
+  <component :is="type" :href="href" class="btn" :class="classes">
     <slot></slot>
   </component>
 </template>

--- a/src/components/MostUsedLocationButtons.vue
+++ b/src/components/MostUsedLocationButtons.vue
@@ -24,10 +24,15 @@ const buttons = computed(() =>
 <template>
   <div class="space-y-2">
     <div v-for="{ label, connection } in buttons" :key="label" class="flex gap-2">
-      <Button class="flex-1 truncate" @click="selectLocation(connection)">
+      <Button class="flex-1" whitespace="normal" @click="selectLocation(connection)">
         {{ label }}
       </Button>
-      <Button color="error" size="small" @click="removeEntry(connection)">
+      <Button
+        class="flex flex-items-center"
+        color="error"
+        size="small"
+        @click="removeEntry(connection)"
+      >
         <FeTrash />
       </Button>
     </div>

--- a/src/components/Proxy/CustomProxies.vue
+++ b/src/components/Proxy/CustomProxies.vue
@@ -152,7 +152,7 @@ const clearError = () => {
             <h4 class="font-semibold">Server</h4>
             <div class="ml-2">{{ globalProxyDetails.server }}</div>
           </div>
-          <div class="flex">
+          <div class="flex items-center">
             <h4 class="font-semibold pr-2">Proxy DNS</h4>
             <n-checkbox
               size="large"
@@ -232,7 +232,7 @@ const clearError = () => {
               <h4 class="font-semibold">Server</h4>
               <div class="ml-2">{{ hostProxiesDetails[host].server }}</div>
             </div>
-            <div class="flex">
+            <div class="flex items-center">
               <h4 class="font-semibold pr-2">Proxy DNS</h4>
               <n-checkbox
                 size="large"

--- a/src/components/RecentLocationButtons.vue
+++ b/src/components/RecentLocationButtons.vue
@@ -24,10 +24,15 @@ const buttons = computed(() =>
 <template>
   <div class="space-y-2">
     <div v-for="{ label, connection } in buttons" :key="label" class="flex gap-2">
-      <Button class="flex-1 truncate" @click="selectLocation(connection)">
+      <Button class="flex-1" whitespace="normal" @click="selectLocation(connection)">
         {{ label }}
       </Button>
-      <Button color="error" size="small" @click="removeEntry(connection)">
+      <Button
+        class="flex flex-items-center"
+        color="error"
+        size="small"
+        @click="removeEntry(connection)"
+      >
         <FeTrash />
       </Button>
     </div>

--- a/src/components/__snapshots__/MostUsedLocationButtons.test.ts.snap
+++ b/src/components/__snapshots__/MostUsedLocationButtons.test.ts.snap
@@ -9,7 +9,7 @@ exports[`MostUsedLocationButtons > should render one select button and one remov
     class="flex gap-2"
   >
     <button
-      class="btn whitespace-nowrap flex-1 truncate"
+      class="btn whitespace-normal flex-1"
       data-v-814a3da6=""
     >
       
@@ -17,7 +17,7 @@ exports[`MostUsedLocationButtons > should render one select button and one remov
       
     </button>
     <button
-      class="btn whitespace-nowrap bg-error text-white btn-small"
+      class="btn whitespace-nowrap bg-error text-white btn-small flex flex-items-center"
       data-v-814a3da6=""
     >
       
@@ -66,7 +66,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
     class="flex gap-2"
   >
     <button
-      class="btn whitespace-nowrap flex-1 truncate"
+      class="btn whitespace-normal flex-1"
       data-v-814a3da6=""
     >
       
@@ -74,7 +74,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
       
     </button>
     <button
-      class="btn whitespace-nowrap bg-error text-white btn-small"
+      class="btn whitespace-nowrap bg-error text-white btn-small flex flex-items-center"
       data-v-814a3da6=""
     >
       
@@ -114,7 +114,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
     class="flex gap-2"
   >
     <button
-      class="btn whitespace-nowrap flex-1 truncate"
+      class="btn whitespace-normal flex-1"
       data-v-814a3da6=""
     >
       
@@ -122,7 +122,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
       
     </button>
     <button
-      class="btn whitespace-nowrap bg-error text-white btn-small"
+      class="btn whitespace-nowrap bg-error text-white btn-small flex flex-items-center"
       data-v-814a3da6=""
     >
       
@@ -162,7 +162,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
     class="flex gap-2"
   >
     <button
-      class="btn whitespace-nowrap flex-1 truncate"
+      class="btn whitespace-normal flex-1"
       data-v-814a3da6=""
     >
       
@@ -170,7 +170,7 @@ exports[`MostUsedLocationButtons > should render three proxy servers select butt
       
     </button>
     <button
-      class="btn whitespace-nowrap bg-error text-white btn-small"
+      class="btn whitespace-nowrap bg-error text-white btn-small flex flex-items-center"
       data-v-814a3da6=""
     >
       

--- a/src/composables/useProxyHistory/useProxyHistory.ts
+++ b/src/composables/useProxyHistory/useProxyHistory.ts
@@ -26,9 +26,8 @@ const storeSocksProxyUsage = (entry: HistoryEntryDetails) => {
 
 const getLabel = (historyEntry: HistoryEntry) => {
   const { country, countryCode, city, hostname } = historyEntry;
-  const servername = hostname.split('.relays.mullvad.net')[0];
 
-  return `${city ? city + `, ${countryCode.toUpperCase()}` : country} (${servername})`;
+  return `${city ? city + `, ${countryCode.toUpperCase()}` : country} (${hostname})`;
 };
 
 const removeEntry = (entry: HistoryEntry) => {

--- a/src/composables/useSocksProxies.ts
+++ b/src/composables/useSocksProxies.ts
@@ -28,9 +28,16 @@ const getSocksProxies = async () => {
   try {
     const response = await fetch(SOCKS_API_URL);
     const data: SocksProxy[] = await response.json();
-    flatProxiesList.value = data.filter((proxy: SocksProxy) => {
-      return proxy.online && proxy.ipv4_address && proxy.hostname;
-    });
+    flatProxiesList.value = data
+      .filter((proxy: SocksProxy) => {
+        return proxy.online && proxy.ipv4_address && proxy.hostname;
+      })
+      .map((proxy: SocksProxy) => {
+        proxy.hostname = proxy.hostname
+          .replace('wg-socks5-', '')
+          .replace('.relays.mullvad.net', '');
+        return proxy;
+      });
   } catch (e: unknown) {
     isError.value = true;
 

--- a/src/composables/useSocksProxy.ts
+++ b/src/composables/useSocksProxy.ts
@@ -190,7 +190,7 @@ const setGlobalProxy = ({
 
   const newGlobalProxyDetails: ProxyDetails = {
     socksEnabled: true,
-    server: hostname!.replace('socks5-', '')!.replace('.relays.mullvad.net', ''),
+    server: hostname,
     country: country,
     countryCode: countryCode,
     city: city,
@@ -227,7 +227,7 @@ const setCustomProxy = (
 
   const newHostProxyDetails: ProxyDetails = {
     socksEnabled: true,
-    server: hostname!.replace('socks5-', '')!.replace('.relays.mullvad.net', ''),
+    server: hostname,
     country: country,
     countryCode: countryCode,
     city: city,

--- a/src/helpers/socksProxy/getRandomSessionProxy.ts
+++ b/src/helpers/socksProxy/getRandomSessionProxy.ts
@@ -39,7 +39,7 @@ export async function getRandomSessionProxy(domain: string) {
 
       const proxyDetails: ProxyDetails = {
         socksEnabled: true,
-        server: randomProxy.hostname!.replace('socks5-', '')!.replace('.relays.mullvad.net', ''),
+        server: randomProxy.hostname,
         country: randomProxy.location.country,
         countryCode: addCountryCodeToProxy(randomProxy).location.countryCode,
         city: randomProxy.location.city,

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -11,4 +11,5 @@ export default defineConfig({
       sans: "'Source Sans Pro', Helvetica, Arial, sans-serif",
     },
   },
+  safelist: ['whitespace-normal', 'whitespace-nowrap'],
 });


### PR DESCRIPTION
Fixes #364

Allow Button component to use `whitespace-normal` class so the text can wrap if needed.
Update MostUsedLocationButtons and RecentLocationButtons to not truncate text and use `whitespace-normal`.
Update MostUsedLocationButtons and RecentLocationButtons to center the trash icon vertically.
