### PR TITLE
Tighten the local/reserved IP parsing

### DIFF
--- a/src/helpers/socksProxy/socksProxy.test.ts
+++ b/src/helpers/socksProxy/socksProxy.test.ts
@@ -24,8 +24,19 @@ describe('isLocalOrReservedIP', () => {
     expect(isLocalOrReservedIP('::1')).toBeTruthy();
   });
 
+  it('should return true for bracketed IPv6', () => {
+    expect(isLocalOrReservedIP('[::1]')).toBeTruthy();
+    expect(isLocalOrReservedIP('[fc00::1]')).toBeTruthy();
+  });
+
   it('should return false for public IP', () => {
     expect(isLocalOrReservedIP('8.8.8.8')).toBeFalsy();
+  });
+
+  it('should return false for domains that contain the localhost substring', () => {
+    expect(isLocalOrReservedIP('notlocalhost.com')).toBeFalsy();
+    expect(isLocalOrReservedIP('localhost.attacker.tld')).toBeFalsy();
+    expect(isLocalOrReservedIP('prod-localhost-cdn.example')).toBeFalsy();
   });
 
   it('should return false for invalid IP', () => {

--- a/src/helpers/socksProxy/socksProxy.ts
+++ b/src/helpers/socksProxy/socksProxy.ts
@@ -1,4 +1,5 @@
 import ipaddr from 'ipaddr.js';
+import { parse } from 'tldts';
 
 import {
   RequestDetails,
@@ -159,11 +160,16 @@ export const isExtConnCheck = (
 };
 
 export const isLocalOrReservedIP = (hostname: string) => {
-  if (hostname.includes('localhost')) return true;
-  if (!ipaddr.isValid(hostname)) return false;
+  //Parse with `tldts` to normalize the host (it strips the brackets for IPv6 and lowercases),
+  // and to match "localhost" via the special-use flag.
+  const parsed = parse(hostname, { detectSpecialUse: true });
+  const normalizedHost = parsed.hostname;
+  if (!normalizedHost) return false;
+  if (parsed.isSpecialUse && normalizedHost === 'localhost') return true;
+  if (!ipaddr.isValid(normalizedHost)) return false;
 
   try {
-    const addr = ipaddr.parse(hostname);
+    const addr = ipaddr.parse(normalizedHost);
     const range = addr.range();
 
     return (


### PR DESCRIPTION
There was a proxy bypass because of the crude localhost parsing, fixed by using tldts. Additionally, bracketed IPv6 were not parsed correctly.